### PR TITLE
fix: Fix incorrect Javadoc

### DIFF
--- a/src/main/java/io/github/treesitter/jtreesitter/Language.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/Language.java
@@ -60,12 +60,9 @@ public final class Language {
      * <h4 id="load-example">Example</h4>
      *
      * <p>{@snippet lang="java" :
-     * Language language;
-     * try (Arena arena = Arena.ofConfined()) {
-     *    String library = System.mapLibraryName("tree-sitter-java");
-     *    SymbolLookup symbols = SymbolLookup.libraryLookup(library, arena);
-     *    language = Language.load(symbols, "tree_sitter_java");
-     * }
+     * String library = System.mapLibraryName("tree-sitter-java");
+     * SymbolLookup symbols = SymbolLookup.libraryLookup(library, Arena.ofAuto());
+     * Language language = Language.load(symbols, "tree_sitter_java");
      * }
      *
      * @throws RuntimeException If the language could not be loaded.

--- a/src/main/java/io/github/treesitter/jtreesitter/package-info.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/package-info.java
@@ -15,7 +15,10 @@
  * <li>Shared libraries for languages</li>
  * </ul>
  *
- * <em>The shared libraries must be installed system-wide or in {@systemProperty java.library.path}</em>
+ * <em>The shared libraries must be installed in the OS-specific library path.</em>
+ * For example on Unix the `libtree-sitter.so` might have to be on `LD_LIBRARY_PATH`
+ * and on Windows `tree-sitter.dll` has to be in the current working directory or `PATH`
+ * (see the documentation of your OS for details).
  *
  * <h2 id="usage">Basic Usage</h2>
  *


### PR DESCRIPTION
For loading a `Language` cannot use `Arena.ofConfined()` because that will directly unload the library again and then seems to crash the JVM afterwards, at least on Windows.

And `SymbolLookup#libraryLookup` does not consider `java.library.path`, see https://bugs.openjdk.org/browse/JDK-8311090 and my comment on https://github.com/tree-sitter/tree-sitter-java/pull/182#discussion_r1741237367.