### PR TITLE
fix(query): fix overflow for capture count

### DIFF
--- a/src/main/java/io/github/treesitter/jtreesitter/Query.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/Query.java
@@ -544,10 +544,10 @@ public final class Query implements AutoCloseable {
         public boolean tryAdvance(Consumer<? super QueryMatch> action) {
             MemorySegment match = arena.allocate(TSQueryMatch.layout());
             if (!ts_query_cursor_next_match(cursor, match)) return false;
-            var count = TSQueryMatch.capture_count(match);
+            var count = Short.toUnsignedInt(TSQueryMatch.capture_count(match));
             var matchCaptures = TSQueryMatch.captures(match);
             var captureList = new ArrayList<QueryCapture>(count);
-            for (short i = 0; i < count; ++i) {
+            for (int i = 0; i < count; ++i) {
                 var capture = TSQueryCapture.asSlice(matchCaptures, i);
                 var name = captureNames.get(TSQueryCapture.index(capture));
                 var node = TSNode.allocate(arena).copyFrom(TSQueryCapture.node(capture));

--- a/src/test/java/io/github/treesitter/jtreesitter/QueryTest.java
+++ b/src/test/java/io/github/treesitter/jtreesitter/QueryTest.java
@@ -288,5 +288,17 @@ class QueryTest {
                         "Foo", matches.getFirst().captures().getFirst().node().getText());
             });
         }
+
+        // Verify that capture count is treated as `uint16_t` and not as signed Java `short`
+        try (var tree = parser.parse(";".repeat(Short.MAX_VALUE + 1)).orElseThrow()) {
+            var source = """
+                ";"+ @capture
+                """;
+            assertQuery(source, query -> {
+                var matches = query.findMatches(tree.getRootNode()).toList();
+                assertEquals(1, matches.size());
+                assertEquals(Short.MAX_VALUE + 1, matches.getFirst().captures().size());
+            });
+        }
     }
 }


### PR DESCRIPTION
`TSQueryMatch#capture_count` returns an `uint16_t`, but currently it is handled as signed Java `short`, for example a match with `Short.MAX_VALUE + 1` captures leads to:
```
java.lang.IllegalArgumentException: Illegal Capacity: -32768
	at java.base/java.util.ArrayList.<init>(ArrayList.java:161)
	at io.github.treesitter.jtreesitter.Query$MatchesIterator.tryAdvance(Query.java:549)
	...
```

Side note: It seems the capture count can also overflow `uint16_t` internally in tree-sitter.