### PR TITLE
fix(query): implement predicate evaluation iteratively

### DIFF
--- a/src/main/java/io/github/treesitter/jtreesitter/Query.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/Query.java
@@ -542,24 +542,26 @@ public final class Query implements AutoCloseable {
 
         @Override
         public boolean tryAdvance(Consumer<? super QueryMatch> action) {
-            MemorySegment match = arena.allocate(TSQueryMatch.layout());
-            if (!ts_query_cursor_next_match(cursor, match)) return false;
-            var count = TSQueryMatch.capture_count(match);
-            var matchCaptures = TSQueryMatch.captures(match);
-            var captureList = new ArrayList<QueryCapture>(count);
-            for (short i = 0; i < count; ++i) {
-                var capture = TSQueryCapture.asSlice(matchCaptures, i);
-                var name = captureNames.get(TSQueryCapture.index(capture));
-                var node = TSNode.allocate(arena).copyFrom(TSQueryCapture.node(capture));
-                captureList.add(new QueryCapture(name, new Node(node, tree)));
+            boolean hasNoText = tree.getText() == null;
+            while (true) {
+                MemorySegment match = arena.allocate(TSQueryMatch.layout());
+                if (!ts_query_cursor_next_match(cursor, match)) return false;
+                var count = TSQueryMatch.capture_count(match);
+                var matchCaptures = TSQueryMatch.captures(match);
+                var captureList = new ArrayList<QueryCapture>(count);
+                for (short i = 0; i < count; ++i) {
+                    var capture = TSQueryCapture.asSlice(matchCaptures, i);
+                    var name = captureNames.get(TSQueryCapture.index(capture));
+                    var node = TSNode.allocate(arena).copyFrom(TSQueryCapture.node(capture));
+                    captureList.add(new QueryCapture(name, new Node(node, tree)));
+                }
+                var patternIndex = TSQueryMatch.pattern_index(match);
+                var result = new QueryMatch(patternIndex, captureList);
+                if (hasNoText || matches(predicate, result)) {
+                    action.accept(result);
+                    return true;
+                }
             }
-            var patternIndex = TSQueryMatch.pattern_index(match);
-            var result = new QueryMatch(patternIndex, captureList);
-            if (tree.getText() == null || matches(predicate, result)) {
-                action.accept(result);
-                return true;
-            }
-            return tryAdvance(action);
         }
     }
 }


### PR DESCRIPTION
The previous recursive implementation could lead to a StackOverflowError if a predicate returned `false` very often.