### PR TITLE
Fix UTF16 byte order + extend utf8 & utf16 test

### DIFF
--- a/src/main/java/io/github/treesitter/jtreesitter/InputEncoding.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/InputEncoding.java
@@ -1,5 +1,6 @@
 package io.github.treesitter.jtreesitter;
 
+import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.jspecify.annotations.NonNull;
@@ -9,7 +10,7 @@ public enum InputEncoding {
     /** UTF-8 encoding. */
     UTF_8(StandardCharsets.UTF_8),
     /** UTF-16 encoding. */
-    UTF_16(StandardCharsets.UTF_16BE);
+    UTF_16(ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN ? StandardCharsets.UTF_16BE : StandardCharsets.UTF_16LE);
 
     private final @NonNull Charset charset;
 
@@ -24,12 +25,14 @@ public enum InputEncoding {
     /**
      * Convert a standard {@linkplain Charset} to an {@linkplain InputEncoding}.
      *
-     * @param charset one of {@link StandardCharsets#UTF_8} or {@link StandardCharsets#UTF_16BE}
+     * @param charset one of {@link StandardCharsets#UTF_8} or {@link StandardCharsets#UTF_16} ({@link StandardCharsets#UTF_16LE UTF_16LE} and {@link StandardCharsets#UTF_16BE UTF_16BE} will work too, but native byte order will be used)
      * @throws IllegalArgumentException If the character set is invalid.
      */
     static @NonNull InputEncoding valueOf(@NonNull Charset charset) throws IllegalArgumentException {
         if (charset.equals(StandardCharsets.UTF_8)) return InputEncoding.UTF_8;
-        if (charset.equals(StandardCharsets.UTF_16BE)) return InputEncoding.UTF_16;
+        if (charset.equals(StandardCharsets.UTF_16BE)
+                || charset.equals(StandardCharsets.UTF_16LE)
+                || charset.equals(StandardCharsets.UTF_16)) return InputEncoding.UTF_16;
         throw new IllegalArgumentException("Invalid character set: %s".formatted(charset));
     }
 }

--- a/src/test/java/io/github/treesitter/jtreesitter/ParserTest.java
+++ b/src/test/java/io/github/treesitter/jtreesitter/ParserTest.java
@@ -78,7 +78,11 @@ class ParserTest {
     void parseUtf8() {
         parser.setLanguage(language);
         try (var tree = parser.parse("class Foo {}").orElseThrow()) {
-            assertEquals(12, tree.getRootNode().getEndByte());
+            var rootNode = tree.getRootNode();
+
+            assertEquals(12, rootNode.getEndByte());
+            assertFalse(rootNode.isError());
+            assertEquals("(program (class_declaration name: (identifier) body: (class_body)))", rootNode.toSexp());
         }
     }
 
@@ -87,7 +91,13 @@ class ParserTest {
     void parseUtf16() {
         parser.setLanguage(language);
         try (var tree = parser.parse("var java = \"💩\";", InputEncoding.UTF_16).orElseThrow()) {
-            assertEquals(32, tree.getRootNode().getEndByte());
+            var rootNode = tree.getRootNode();
+
+            assertEquals(32, rootNode.getEndByte());
+            assertFalse(rootNode.isError());
+            assertEquals(
+                    "(program (local_variable_declaration type: (type_identifier) declarator: (variable_declarator name: (identifier) value: (string_literal (string_fragment)))))",
+                    rootNode.toSexp());
         }
     }
 


### PR DESCRIPTION
This fixes #40 by using `ByteOrder.nativeOrder()`.

I changed `InputEncoding.valueOf`to accept  `StandardCharsets.UTF_16BE`, `StandardCharsets.UTF_16LE` and `StandardCharsets.UTF_16` but ignore the endianness (to stay backwards compatible with e.g. a big-endian machine). 

I also changed the `parseUtf8` and `parseUtf16` tests to verify that their small example code are actually parsed correctly.