### PR TITLE
fix(node): use source encoding in `getText()`

### DIFF
--- a/src/main/java/io/github/treesitter/jtreesitter/Node.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/Node.java
@@ -21,6 +21,7 @@ public final class Node {
     private final Tree tree;
     private @Nullable List<Node> children;
     private final Arena arena = Arena.ofAuto();
+    private boolean wasEdited = false;
 
     Node(MemorySegment self, Tree tree) {
         this.self = self;
@@ -409,10 +410,7 @@ public final class Node {
 
     /** Get the source code of the node, if available. */
     public @Nullable String getText() {
-        var text = tree.getText();
-        if (text == null) return null;
-        var endByte = Math.min(getEndByte(), text.length());
-        return text.substring(getStartByte(), endByte);
+        return !wasEdited ? tree.getRegion(getStartByte(), getEndByte()) : null;
     }
 
     /**
@@ -426,6 +424,7 @@ public final class Node {
      */
     public void edit(InputEdit edit) {
         ts_node_edit(self, edit.into(arena));
+        wasEdited = true;
         children = null;
     }
 

--- a/src/main/java/io/github/treesitter/jtreesitter/Parser.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/Parser.java
@@ -244,7 +244,7 @@ public final class Parser implements AutoCloseable {
             var old = oldTree == null ? MemorySegment.NULL : oldTree.segment();
             var tree = ts_parser_parse_string_encoding(self, old, string, bytes.length, encoding.ordinal());
             if (tree.equals(MemorySegment.NULL)) return Optional.empty();
-            return Optional.of(new Tree(tree, language, source));
+            return Optional.of(new Tree(tree, language, source, encoding.charset()));
         }
     }
 
@@ -299,7 +299,7 @@ public final class Parser implements AutoCloseable {
         var old = oldTree == null ? MemorySegment.NULL : oldTree.segment();
         var tree = ts_parser_parse(self, old, input);
         if (tree.equals(MemorySegment.NULL)) return Optional.empty();
-        return Optional.of(new Tree(tree, language, null));
+        return Optional.of(new Tree(tree, language, null, null));
     }
 
     /**

--- a/src/test/java/io/github/treesitter/jtreesitter/NodeTest.java
+++ b/src/test/java/io/github/treesitter/jtreesitter/NodeTest.java
@@ -13,7 +13,7 @@ class NodeTest {
     static void beforeAll() {
         var language = new Language(TreeSitterJava.language());
         try (var parser = new Parser(language)) {
-            tree = parser.parse("class Foo {}").orElseThrow();
+            tree = parser.parse("class Foo {} // uni©ode").orElseThrow();
             node = tree.getRootNode();
         }
     }
@@ -100,13 +100,13 @@ class NodeTest {
 
     @Test
     void getEndByte() {
-        assertEquals(12, node.getEndByte());
+        assertEquals(24, node.getEndByte());
     }
 
     @Test
     void getRange() {
-        Point startPoint = new Point(0, 0), endPoint = new Point(0, 12);
-        assertEquals(new Range(startPoint, endPoint, 0, 12), node.getRange());
+        Point startPoint = new Point(0, 0), endPoint = new Point(0, 24);
+        assertEquals(new Range(startPoint, endPoint, 0, 24), node.getRange());
     }
 
     @Test
@@ -116,22 +116,22 @@ class NodeTest {
 
     @Test
     void getEndPoint() {
-        assertEquals(new Point(0, 12), node.getEndPoint());
+        assertEquals(new Point(0, 24), node.getEndPoint());
     }
 
     @Test
     void getChildCount() {
-        assertEquals(1, node.getChildCount());
+        assertEquals(2, node.getChildCount());
     }
 
     @Test
     void getNamedChildCount() {
-        assertEquals(1, node.getNamedChildCount());
+        assertEquals(2, node.getNamedChildCount());
     }
 
     @Test
     void getDescendantCount() {
-        assertEquals(7, node.getDescendantCount());
+        assertEquals(8, node.getDescendantCount());
     }
 
     @Test
@@ -273,8 +273,8 @@ class NodeTest {
 
     @Test
     void getText() {
-        var child = node.getDescendant(6, 9).orElseThrow();
-        assertEquals("Foo", child.getText());
+        var child = node.getChild(1).orElseThrow();
+        assertEquals("// uni©ode", child.getText());
     }
 
     @Test
@@ -298,7 +298,7 @@ class NodeTest {
 
     @Test
     void toSexp() {
-        var sexp = "(program (class_declaration name: (identifier) body: (class_body)))";
+        var sexp = "(program (class_declaration name: (identifier) body: (class_body)) (line_comment))";
         assertEquals(sexp, node.toSexp());
     }
 


### PR DESCRIPTION
Closes #27 