### PR TITLE
Possibility to use custom allocators for nodes retrieved from cursors and queries

### DIFF
--- a/src/main/java/io/github/treesitter/jtreesitter/TreeCursor.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/TreeCursor.java
@@ -4,6 +4,7 @@ import static io.github.treesitter.jtreesitter.internal.TreeSitter.*;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SegmentAllocator;
 import java.util.OptionalInt;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -36,13 +37,27 @@ public final class TreeCursor implements AutoCloseable, Cloneable {
         node = cursor.node;
     }
 
-    /** Get the current node of the cursor. */
+    /**
+     * Get the current node of the cursor.
+     *
+     * @implNote The node will become invalid once the cursor is closed.
+     */
     public Node getCurrentNode() {
         if (this.node == null) {
             var node = ts_tree_cursor_current_node(arena, self);
             this.node = new Node(node, tree);
         }
         return this.node;
+    }
+
+    /**
+     * Get the current node of the cursor using the given allocator.
+     *
+     * @since 0.25.0
+     */
+    public Node getCurrentNode(SegmentAllocator allocator) {
+        var node = ts_tree_cursor_current_node(allocator, self);
+        return new Node(node, tree);
     }
 
     /**

--- a/src/test/java/io/github/treesitter/jtreesitter/TreeCursorTest.java
+++ b/src/test/java/io/github/treesitter/jtreesitter/TreeCursorTest.java
@@ -3,7 +3,13 @@ package io.github.treesitter.jtreesitter;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.github.treesitter.jtreesitter.languages.TreeSitterJava;
-import org.junit.jupiter.api.*;
+import java.lang.foreign.Arena;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 class TreeCursorTest {
     private static Tree tree;
@@ -37,6 +43,15 @@ class TreeCursorTest {
         var node = cursor.getCurrentNode();
         assertEquals(tree.getRootNode(), node);
         assertSame(node, cursor.getCurrentNode());
+
+        try (var arena = Arena.ofConfined()) {
+            try (var copy = cursor.clone()) {
+                node = copy.getCurrentNode(arena);
+                assertEquals(node, tree.getRootNode());
+            }
+            // can still access node after cursor was closed
+            assertEquals(node, tree.getRootNode());
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #57 

Allows to use a custom `SegmentAllocator` when retrieving node instances from cursors and queries. This allows for using the nodes even after the cursor / query has been closed. Also it gives the caller the opportunity to clear the memory of a node without closing the cursor / query in case a lot of nodes are retrieved without closing the cursor / query.

Note: This PR also removes the cached java node object in the `TreeCursor` class as we do now longer control the lifetime of its native memory. I hope this is ok as recreating it (in case somebody retrieves the same node twice) should not be that expensive.