### PR TITLE
Add access to source bytes and charset of a tree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/io/github/treesitter/jtreesitter/Parser.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/Parser.java
@@ -244,7 +244,7 @@ public final class Parser implements AutoCloseable {
             var old = oldTree == null ? MemorySegment.NULL : oldTree.segment();
             var tree = ts_parser_parse_string_encoding(self, old, string, bytes.length, encoding.ordinal());
             if (tree.equals(MemorySegment.NULL)) return Optional.empty();
-            return Optional.of(new Tree(tree, language, source, encoding.charset()));
+            return Optional.of(new Tree(tree, language, bytes, encoding.charset()));
         }
     }
 

--- a/src/main/java/io/github/treesitter/jtreesitter/Tree.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/Tree.java
@@ -148,7 +148,7 @@ public final class Tree implements AutoCloseable, Cloneable {
         try (var alloc = Arena.ofConfined()) {
             ts_tree_edit(self, edit.into(alloc));
         } finally {
-            source = new byte[0];
+            source = null;
             charset = null;
         }
     }

--- a/src/main/java/io/github/treesitter/jtreesitter/Tree.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/Tree.java
@@ -16,7 +16,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public final class Tree implements AutoCloseable, Cloneable {
     private final MemorySegment self;
-    private byte[] source;
+    private byte @Nullable [] source;
     private @Nullable Charset charset;
     private final Arena arena;
     private final Language language;
@@ -25,11 +25,11 @@ public final class Tree implements AutoCloseable, Cloneable {
     // FIXME: figure out why free() crashes on Windows
     private static final boolean IS_UNIX = !System.getProperty("os.name").startsWith("Windows");
 
-    Tree(MemorySegment self, Language language, @Nullable String source, @Nullable Charset charset) {
+    Tree(MemorySegment self, Language language, byte @Nullable [] source, @Nullable Charset charset) {
         arena = Arena.ofShared();
         this.self = self.reinterpret(arena, TreeSitter::ts_tree_delete);
         this.language = language;
-        this.source = source != null && charset != null ? source.getBytes(charset) : new byte[0];
+        this.source = source;
         this.charset = charset;
     }
 
@@ -49,6 +49,9 @@ public final class Tree implements AutoCloseable, Cloneable {
 
     @Nullable
     String getRegion(@Unsigned int start, @Unsigned int end) {
+        if (source == null) {
+            return null;
+        }
         var length = Math.min(end, source.length) - start;
         return charset != null ? new String(source, start, length, charset) : null;
     }

--- a/src/main/java/io/github/treesitter/jtreesitter/Tree.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/Tree.java
@@ -58,9 +58,19 @@ public final class Tree implements AutoCloseable, Cloneable {
         return language;
     }
 
-    /** Get the source code of the syntax tree, if available. */
+    /** Get the source code of the syntax tree parsed as a string, if available. */
     public @Nullable String getText() {
         return charset != null ? new String(source, charset) : null;
+    }
+
+    /** Get the source code of the syntax tree as raw bytes, if available. */
+    public byte @Nullable [] getSourceBytes() {
+        return source;
+    }
+
+    /** Get the charset of the source code bytes, if available. */
+    public @Nullable Charset getCharset() {
+        return charset;
     }
 
     /** Get the root node of the syntax tree. */

--- a/src/test/java/io/github/treesitter/jtreesitter/TreeTest.java
+++ b/src/test/java/io/github/treesitter/jtreesitter/TreeTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class TreeTest {
     private static final String source = "class Foo {}";
@@ -43,6 +45,19 @@ class TreeTest {
     @Test
     void getText() {
         assertEquals(source, tree.getText());
+    }
+
+    @Test
+    void getSourceBytes() {
+        assertArrayEquals(source.getBytes(tree.getCharset()), tree.getSourceBytes());
+    }
+
+    @ParameterizedTest
+    @EnumSource(InputEncoding.class)
+    void getCharset(InputEncoding encoding) {
+        try (Tree t = parser.parse(source, encoding).orElseThrow()) {
+            assertEquals(encoding.charset(), t.getCharset());
+        }
     }
 
     @Test


### PR DESCRIPTION
This change avoids unnecessary conversions if users of the library want to work with the raw source bytes instead of a parsed string.