### PR TITLE
test(parser): fix incorrect progress callback implementation

### DIFF
--- a/src/test/java/io/github/treesitter/jtreesitter/ParserTest.java
+++ b/src/test/java/io/github/treesitter/jtreesitter/ParserTest.java
@@ -160,7 +160,7 @@ class ParserTest {
         var source = "}".repeat(1024);
         // NOTE: can't use _ because of palantir/palantir-java-format#934
         ParseCallback callback = (offset, p) -> source.substring(offset, Integer.min(source.length(), offset + 1));
-        var options = new Parser.Options((state) -> state.getCurrentByteOffset() <= 1000);
+        var options = new Parser.Options((state) -> state.getCurrentByteOffset() >= 1000);
 
         parser.setLanguage(language);
         assertTrue(parser.parse(callback, InputEncoding.UTF_8, options).isEmpty());


### PR DESCRIPTION
The progress callback has to return `true` to cancel, and `false` to continue.

See https://github.com/tree-sitter/java-tree-sitter/pull/90#discussion_r2012982544