### PR TITLE
feat(inputencoding): use C enum values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/io/github/treesitter/jtreesitter/InputEncoding.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/InputEncoding.java
@@ -1,5 +1,9 @@
 package io.github.treesitter.jtreesitter;
 
+import static io.github.treesitter.jtreesitter.internal.TreeSitter.TSInputEncodingUTF16BE;
+import static io.github.treesitter.jtreesitter.internal.TreeSitter.TSInputEncodingUTF16LE;
+import static io.github.treesitter.jtreesitter.internal.TreeSitter.TSInputEncodingUTF8;
+
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -8,28 +12,34 @@ import org.jspecify.annotations.NonNull;
 /** The encoding of source code. */
 public enum InputEncoding {
     /** UTF-8 encoding. */
-    UTF_8(StandardCharsets.UTF_8),
+    UTF_8(StandardCharsets.UTF_8, TSInputEncodingUTF8()),
     /**
      * UTF-16 little endian encoding.
      *
      * @since 0.25.0
      */
-    UTF_16LE(StandardCharsets.UTF_16LE),
+    UTF_16LE(StandardCharsets.UTF_16LE, TSInputEncodingUTF16LE()),
     /**
      * UTF-16 big endian encoding.
      *
      * @since 0.25.0
      */
-    UTF_16BE(StandardCharsets.UTF_16BE);
+    UTF_16BE(StandardCharsets.UTF_16BE, TSInputEncodingUTF16BE());
 
     private final @NonNull Charset charset;
+    private final int tsInputEncoding;
 
-    InputEncoding(@NonNull Charset charset) {
+    InputEncoding(@NonNull Charset charset, int tsInputEncoding) {
         this.charset = charset;
+        this.tsInputEncoding = tsInputEncoding;
     }
 
     Charset charset() {
         return charset;
+    }
+
+    int tsInputEncoding() {
+        return tsInputEncoding;
     }
 
     private static final boolean IS_BIG_ENDIAN = ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN);

--- a/src/main/java/io/github/treesitter/jtreesitter/Parser.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/Parser.java
@@ -254,7 +254,7 @@ public final class Parser implements AutoCloseable {
             var bytes = source.getBytes(encoding.charset());
             var string = alloc.allocateFrom(C_CHAR, bytes);
             var old = oldTree == null ? MemorySegment.NULL : oldTree.segment();
-            var tree = ts_parser_parse_string_encoding(self, old, string, bytes.length, encoding.ordinal());
+            var tree = ts_parser_parse_string_encoding(self, old, string, bytes.length, encoding.tsInputEncoding());
             if (tree.equals(MemorySegment.NULL)) return Optional.empty();
             return Optional.of(new Tree(tree, language, source, encoding.charset()));
         }
@@ -303,7 +303,7 @@ public final class Parser implements AutoCloseable {
 
         var input = TSInput.allocate(arena);
         TSInput.payload(input, MemorySegment.NULL);
-        TSInput.encoding(input, encoding.ordinal());
+        TSInput.encoding(input, encoding.tsInputEncoding());
         // NOTE: can't use _ because of palantir/palantir-java-format#934
         var read = TSInput.read.allocate(
                 (payload, index, point, bytes) -> {

--- a/src/test/java/io/github/treesitter/jtreesitter/ParserTest.java
+++ b/src/test/java/io/github/treesitter/jtreesitter/ParserTest.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class ParserTest {
     private static Language language;
@@ -83,6 +85,21 @@ class ParserTest {
             assertEquals(
                     "(program (local_variable_declaration type: (type_identifier) declarator: (variable_declarator name: (identifier) value: (string_literal (string_fragment)))))",
                     rootNode.toSexp());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(InputEncoding.class)
+    @DisplayName("parse(encoding)")
+    void parseEncoding(InputEncoding encoding) {
+        parser.setLanguage(language);
+        var source = "var text = \"☕ﬁ𝄞\";";
+        try (var tree = parser.parse(source, encoding).orElseThrow()) {
+            var rootNode = tree.getRootNode();
+
+            assertFalse(rootNode.isError());
+            assertEquals(source, tree.getText());
+            assertEquals(source, rootNode.getText());
         }
     }
 


### PR DESCRIPTION
The current implementation implicitly relies on the following:
- That the C enum values in tree-sitter start at 0 and have consecutive values
- That Java enum's `ordinal()` begins at 0
- That the C and Java enum values are in the same order

Currently all of this is the case, but it feels a bit brittle.

Because the C enum constant values are part of the jextract generated code, it seems more reliable to use them instead.
