### PR TITLE
fix(querypredicate): fix `eq?` causing exception for quantified captures

### DIFF
--- a/src/main/java/io/github/treesitter/jtreesitter/QueryPredicate.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/QueryPredicate.java
@@ -77,9 +77,9 @@ public sealed class QueryPredicate permits QueryPredicate.AnyOf, QueryPredicate.
 
         private boolean testCapture(QueryMatch match) {
             var findNodes1 = match.findNodes(capture).stream();
-            var findNodes2 = match.findNodes(value).stream();
+            var findNodes2 = match.findNodes(value);
             Predicate<Node> predicate =
-                    n1 -> findNodes2.anyMatch(n2 -> Objects.equals(n1.getText(), n2.getText()) == isPositive);
+                    n1 -> findNodes2.stream().anyMatch(n2 -> Objects.equals(n1.getText(), n2.getText()) == isPositive);
             return isAny ? findNodes1.anyMatch(predicate) : findNodes1.allMatch(predicate);
         }
 

--- a/src/test/java/io/github/treesitter/jtreesitter/QueryCursorTest.java
+++ b/src/test/java/io/github/treesitter/jtreesitter/QueryCursorTest.java
@@ -175,5 +175,21 @@ public class QueryCursorTest {
                 assertEquals(Short.MAX_VALUE + 1, matches.getFirst().captures().size());
             });
         }
+
+        // Verify that `eq?` predicate works with quantified captures
+        try (var tree = parser.parse("/* 1 */ /* 1 */ /* 1 */").orElseThrow()) {
+            var source = """
+                (program
+                  . (block_comment) @b (block_comment)+ @a
+                  (#eq? @a @b)
+                )
+                """;
+            assertCursor(source, cursor -> {
+                var matches = cursor.findMatches(tree.getRootNode()).toList();
+                assertEquals(1, matches.size());
+                assertEquals(
+                    "/* 1 */", matches.getFirst().captures().getFirst().node().getText());
+            });
+        }
     }
 }


### PR DESCRIPTION
For quantified captures the `predicate` may be called multiple times, so it must not reuse the already exhausted `Stream`.

Previously the added test was failing with:
```
IllegalStateException: stream has already been operated upon or closed
```