### PR TITLE
Lazily invoke findLibrary to avoid UnsatisfiedLinkError when service loaded SymbolLookup successfuly found library

### DIFF
--- a/src/main/java/io/github/treesitter/jtreesitter/internal/ChainedLibraryLookup.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/internal/ChainedLibraryLookup.java
@@ -21,7 +21,8 @@ final class ChainedLibraryLookup implements NativeLibraryLookup {
         for (var libraryLookup : serviceLoader) {
             lookup = lookup.or(libraryLookup.get(arena));
         }
-        return lookup.or(findLibrary(arena)).or(Linker.nativeLinker().defaultLookup());
+
+        return lookup.or((name) -> findLibrary(arena).find(name)).or(Linker.nativeLinker().defaultLookup());
     }
 
     private static SymbolLookup findLibrary(Arena arena) {


### PR DESCRIPTION
FIX #81 
The problem in ChainedLibraryLookup.get comes from the fact findLibrary is invoked eagerly, thus leading to UnsatisfiedLinkError even when SymbolLookup never requires using the SymbolLookup returned by findLibrary. Actually, the solution is quite simple and it's inspired by the initialization of the lookup local variable.

It leverages the fact SymbolLookup is a FunctionalInterface to implement it in Lazily manner. All you need to do is replace the following line:

`return lookup.or(findLibrary(arena)).or(Linker.nativeLinker().defaultLookup());`

With the following line

`return lookup.or((name) -> findLibrary(arena).find(name)).or(Linker.nativeLinker().defaultLookup());`

Notice that now findLibrary will only execute if all SymbolLookup loaded by ServiceLoader failed to lookup the library.