### PR TITLE
fix: reduce javadoc logo height to prevent navbar overflow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
           </links>
           <excludePackageNames>io.github.treesitter.jtreesitter.internal</excludePackageNames>
           <header><![CDATA[
-          <img src="/tree-sitter/assets/images/tree-sitter-small.png" style="height:2em;width:auto;padding:0.4em" alt="logo"/>
+          <img src="/tree-sitter/assets/images/tree-sitter-small.png" style="height:calc(0.8 * var(--top-nav-height));width:auto;padding:0.4em" alt="logo"/>
           ]]></header>
         </configuration>
       </plugin>


### PR DESCRIPTION
## What problem does this PR solve?

Fixes #154 - Logo in javadoc navbar was overflowing due to `height: 100%`

**Why `height: 100%` didn't work:**  
The logo's direct parent is `.about-language`, not `.top-nav`, so `100%` referenced an intermediate parent without explicit height. This caused the logo to render at its original image size, exceeding the navbar bounds.

**Why `calc(0.8 * var(--top-nav-height))` fixes it:**  
- Directly references the navbar height CSS variable
- 0.8 multiplier provides appropriate visual spacing (~80% of navbar height)
- More stable and maintainable than font-size relative units like `em`

## Changes
Modified `pom.xml` to change logo height from `100%` to `calc(0.8 * var(--top-nav-height))` in the javadoc header configuration.

## Testing
- Tested in Chrome DevTools on the deployed documentation page
- Logo scales appropriately with navbar height
- Visual balance maintained with proper spacing

## Screenshots

**Before**: Logo extends beyond navbar
<img width="485" height="128" alt="image" src="https://github.com/user-attachments/assets/9d525048-721b-4a57-a165-a7b0cd7cbd27" />

**After**: Logo contained within navbar
<img width="448" height="147" alt="image" src="https://github.com/user-attachments/assets/faa4a671-648f-4e3d-a509-a84a6302587b" />

Thanks to @Marcono1234 for suggesting the CSS variable approach!

Fixes #154