### PR TITLE
feat!: update API to 0.26

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tree-sitter"]
     url = https://github.com/tree-sitter/tree-sitter
     path = core
-    branch = release-0.25
+    branch = release-0.26

--- a/scripts/jextract.ps1
+++ b/scripts/jextract.ps1
@@ -90,7 +90,6 @@ $lib = "$($args[0])/core/lib"
     --include-function ts_node_string `
     --include-function ts_node_symbol `
     --include-function ts_node_type `
-    --include-function ts_parser_cancellation_flag `
     --include-function ts_parser_delete `
     --include-function ts_parser_included_ranges `
     --include-function ts_parser_language `
@@ -102,12 +101,10 @@ $lib = "$($args[0])/core/lib"
     --include-function ts_parser_parse_with_options `
     --include-function ts_parser_print_dot_graphs `
     --include-function ts_parser_reset `
-    --include-function ts_parser_set_cancellation_flag `
     --include-function ts_parser_set_included_ranges `
     --include-function ts_parser_set_language `
     --include-function ts_parser_set_logger `
-    --include-function ts_parser_set_timeout_micros `
-    --include-function ts_parser_timeout_micros `
+    --include-function ts_point_edit `
     --include-function ts_query_capture_count `
     --include-function ts_query_capture_name_for_id `
     --include-function ts_query_capture_quantifier_for_id `
@@ -121,11 +118,11 @@ $lib = "$($args[0])/core/lib"
     --include-function ts_query_cursor_next_match `
     --include-function ts_query_cursor_remove_match `
     --include-function ts_query_cursor_set_byte_range `
+    --include-function ts_query_cursor_set_containing_byte_range `
+    --include-function ts_query_cursor_set_containing_point_range `
     --include-function ts_query_cursor_set_match_limit `
     --include-function ts_query_cursor_set_max_start_depth `
     --include-function ts_query_cursor_set_point_range `
-    --include-function ts_query_cursor_set_timeout_micros `
-    --include-function ts_query_cursor_timeout_micros `
     --include-function ts_query_delete `
     --include-function ts_query_disable_capture `
     --include-function ts_query_disable_pattern `
@@ -139,6 +136,7 @@ $lib = "$($args[0])/core/lib"
     --include-function ts_query_start_byte_for_pattern `
     --include-function ts_query_string_count `
     --include-function ts_query_string_value_for_id `
+    --include-function ts_range_edit `
     --include-function ts_tree_copy `
     --include-function ts_tree_cursor_copy `
     --include-function ts_tree_cursor_current_depth `
@@ -193,7 +191,7 @@ $lib = "$($args[0])/core/lib"
     --include-constant TSSymbolTypeAuxiliary `
     --include-constant TSSymbolTypeRegular `
     --include-constant TSSymbolTypeSupertype `
-    --include-typedef DecodeFunction `
+    --include-typedef TSDecodeFunction `
     --header-class-name TreeSitter `
     --output $output `
     -t $package `

--- a/scripts/jextract.sh
+++ b/scripts/jextract.sh
@@ -92,7 +92,6 @@ exec jextract \
     --include-function ts_node_string \
     --include-function ts_node_symbol \
     --include-function ts_node_type \
-    --include-function ts_parser_cancellation_flag \
     --include-function ts_parser_delete \
     --include-function ts_parser_included_ranges \
     --include-function ts_parser_language \
@@ -104,12 +103,10 @@ exec jextract \
     --include-function ts_parser_parse_with_options \
     --include-function ts_parser_print_dot_graphs \
     --include-function ts_parser_reset \
-    --include-function ts_parser_set_cancellation_flag \
     --include-function ts_parser_set_included_ranges \
     --include-function ts_parser_set_language \
     --include-function ts_parser_set_logger \
-    --include-function ts_parser_set_timeout_micros \
-    --include-function ts_parser_timeout_micros \
+    --include-function ts_point_edit \
     --include-function ts_query_capture_count \
     --include-function ts_query_capture_name_for_id \
     --include-function ts_query_capture_quantifier_for_id \
@@ -123,11 +120,11 @@ exec jextract \
     --include-function ts_query_cursor_next_match \
     --include-function ts_query_cursor_remove_match \
     --include-function ts_query_cursor_set_byte_range \
+    --include-function ts_query_cursor_set_containing_byte_range \
+    --include-function ts_query_cursor_set_containing_point_range \
     --include-function ts_query_cursor_set_match_limit \
     --include-function ts_query_cursor_set_max_start_depth \
     --include-function ts_query_cursor_set_point_range \
-    --include-function ts_query_cursor_set_timeout_micros \
-    --include-function ts_query_cursor_timeout_micros \
     --include-function ts_query_delete \
     --include-function ts_query_disable_capture \
     --include-function ts_query_disable_pattern \
@@ -141,6 +138,7 @@ exec jextract \
     --include-function ts_query_start_byte_for_pattern \
     --include-function ts_query_string_count \
     --include-function ts_query_string_value_for_id \
+    --include-function ts_range_edit \
     --include-function ts_tree_copy \
     --include-function ts_tree_cursor_copy \
     --include-function ts_tree_cursor_current_depth \
@@ -195,7 +193,7 @@ exec jextract \
     --include-constant TSSymbolTypeAuxiliary \
     --include-constant TSSymbolTypeRegular \
     --include-constant TSSymbolTypeSupertype \
-    --include-typedef DecodeFunction \
+    --include-typedef TSDecodeFunction \
     --header-class-name TreeSitter \
     --output "$output" \
     -t "$package" \

--- a/src/main/java/io/github/treesitter/jtreesitter/Parser.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/Parser.java
@@ -9,7 +9,6 @@ import java.lang.foreign.MemorySegment;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -53,30 +52,6 @@ public final class Parser implements AutoCloseable {
     }
 
     /**
-     * Get the maximum duration in microseconds that
-     * parsing should be allowed to take before halting.
-     *
-     * @deprecated Use {@link Options} instead.
-     */
-    @Deprecated(since = "0.25.0")
-    public @Unsigned long getTimeoutMicros() {
-        return ts_parser_timeout_micros(self);
-    }
-
-    /**
-     * Set the maximum duration in microseconds that
-     * parsing should be allowed to take before halting.
-     *
-     * @deprecated Use {@link Options} instead.
-     */
-    @Deprecated(since = "0.25.0")
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    public Parser setTimeoutMicros(@Unsigned long timeoutMicros) {
-        ts_parser_set_timeout_micros(self, timeoutMicros);
-        return this;
-    }
-
-    /**
      * Set the logger that the parser will use during parsing.
      *
      * <h4 id="logger-example">Example</h4>
@@ -105,21 +80,6 @@ public final class Parser implements AutoCloseable {
             TSLogger.log(segment, log);
             ts_parser_set_logger(self, segment);
         }
-        return this;
-    }
-
-    /**
-     * Set the parser's current cancellation flag.
-     *
-     * <p>The parser will periodically read from this flag during parsing.
-     * If it reads a non-zero value, it will halt early.
-     *
-     * @deprecated Use {@link Options} instead.
-     */
-    @Deprecated(since = "0.25.0")
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    public synchronized Parser setCancellationFlag(CancellationFlag cancellationFlag) {
-        ts_parser_set_cancellation_flag(self, cancellationFlag.segment);
         return this;
     }
 
@@ -409,33 +369,6 @@ public final class Parser implements AutoCloseable {
 
         private boolean progressCallback(State state) {
             return progressCallback.test(state);
-        }
-    }
-
-    /**
-     * A class representing a cancellation flag.
-     *
-     * @deprecated Use {@link Options} instead.
-     */
-    @Deprecated(since = "0.25.0")
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    public static class CancellationFlag {
-        private final Arena arena = Arena.ofAuto();
-        private final MemorySegment segment = arena.allocate(C_LONG_LONG);
-        private final AtomicLong value = new AtomicLong();
-
-        /** Creates an uninitialized cancellation flag. */
-        public CancellationFlag() {}
-
-        /** Get the value of the flag. */
-        public long get() {
-            return value.get();
-        }
-
-        /** Set the value of the flag. */
-        @SuppressWarnings("unused")
-        public void set(long value) {
-            segment.set(C_LONG_LONG, 0L, this.value.updateAndGet(_ -> value));
         }
     }
 }

--- a/src/main/java/io/github/treesitter/jtreesitter/Range.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/Range.java
@@ -1,6 +1,9 @@
 package io.github.treesitter.jtreesitter;
 
+import static io.github.treesitter.jtreesitter.internal.TreeSitter.*;
+
 import io.github.treesitter.jtreesitter.internal.TSRange;
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
 import org.jspecify.annotations.NullMarked;
@@ -42,6 +45,20 @@ public record Range(Point startPoint, Point endPoint, @Unsigned int startByte, @
         TSRange.start_point(range, startPoint.into(allocator));
         TSRange.end_point(range, endPoint.into(allocator));
         return range;
+    }
+
+    /**
+     * Edit the range to keep it in-sync with source code that has been edited.
+     *
+     * <p>This function updates the range's byte offset and row/column position based on an edit
+     * operation. This is useful for editing ranges without requiring a tree or node instance.
+     *
+     * @since 0.26.0
+     */
+    public void edit(InputEdit edit) {
+        try (var alloc = Arena.ofConfined()) {
+            ts_range_edit(into(alloc), edit.into(alloc));
+        }
     }
 
     @Override

--- a/src/test/java/io/github/treesitter/jtreesitter/LanguageTest.java
+++ b/src/test/java/io/github/treesitter/jtreesitter/LanguageTest.java
@@ -58,10 +58,8 @@ public class LanguageTest {
 
     @Test
     void getSupertypes() {
-        assertArrayEquals(
-            new short[]{ 140, 263, 264, 216, 147, 219, 157, 185 },
-            language.getSupertypes()
-        );
+        short[] supertypes = {140, 263, 264, 216, 147, 219, 157, 185};
+        assertArrayEquals(supertypes, language.getSupertypes());
     }
 
     @Test

--- a/src/test/java/io/github/treesitter/jtreesitter/ParserTest.java
+++ b/src/test/java/io/github/treesitter/jtreesitter/ParserTest.java
@@ -115,43 +115,6 @@ class ParserTest {
     }
 
     @Test
-    @DisplayName("parse(timeout)")
-    @SuppressWarnings("deprecation")
-    void parseTimeout() {
-        var source = "}".repeat(1024);
-        ParseCallback callback = (offset, _) -> source.substring(offset, Integer.min(source.length(), offset + 1));
-
-        parser.setLanguage(language).setTimeoutMicros(2L);
-        assertTrue(parser.parse(callback, InputEncoding.UTF_8).isEmpty());
-    }
-
-    @Test
-    @DisplayName("parse(cancellation)")
-    @SuppressWarnings("deprecation")
-    void parseCancellation() {
-        var source = "}".repeat(1024 * 1024);
-        ParseCallback callback = (offset, _) -> source.substring(offset, Integer.min(source.length(), offset + 1));
-
-        var flag = new Parser.CancellationFlag();
-        parser.setLanguage(language).setCancellationFlag(flag);
-        try (var service = Executors.newFixedThreadPool(2)) {
-            service.submit(() -> {
-                try {
-                    wait(10L);
-                } catch (InterruptedException e) {
-                    service.shutdownNow();
-                } finally {
-                    flag.set(1L);
-                }
-            });
-            var result = service.submit(() -> parser.parse(callback, InputEncoding.UTF_8));
-            assertTrue(result.get(30L, TimeUnit.MILLISECONDS).isEmpty());
-        } catch (InterruptedException | CancellationException | ExecutionException | TimeoutException e) {
-            fail("Parsing was not halted gracefully", e);
-        }
-    }
-
-    @Test
     @DisplayName("parse(options)")
     void parseOptions() {
         var source = "}".repeat(1024);


### PR DESCRIPTION
### Removals

- `Parser.CancellationFlag`
- `Parser#getTimeOutMicros()`
- `Parser#setTimeoutMicros(long)`
- `Parser#setCancellationFlag(Parser.CancellationFlag)`
- `QueryCursor#getTimeoutMicros()`
- `QueryCursor#setTimeoutMicros(long)`

### Additions

- `Point#edit(InputEdit)`
- `Range#edit(InputEdit)`
- `QueryCursor#setContainingByteRange(int, int)`
- `QueryCursor#setContainingPointRange(Point, Point)`