### PR TITLE
ci: ensure portable jextract code, to match deploy release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           JEXTRACT_URL: https://download.java.net/java/early_access/jextract/25/2/openjdk-25-jextract+2-4
       - name: Generate code with jextract
         # NOTE: keep this in sync with deploy
-        run:
+        run: |-
           mvn --no-transfer-progress antrun:run@jextract
           sed -i '${{env.TS_SHARED}}' -e '/C_LONG =/s/"long"/"long long"/'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: true
       - name: Set up Java
@@ -53,9 +53,14 @@ jobs:
           printf '%s/jextract-25/bin\n' "$RUNNER_TOOL_CACHE" >> "$GITHUB_PATH"
         env:
           # NOTE: keep this in sync with deploy, docs
-          JEXTRACT_URL: https://download.java.net/java/early_access/jextract/25/1/openjdk-25-jextract+1-1
-      - name: Generate code
-        run: mvn --no-transfer-progress generate-sources
+          JEXTRACT_URL: https://download.java.net/java/early_access/jextract/25/2/openjdk-25-jextract+2-4
+      - name: Generate code with jextract
+        # NOTE: keep this in sync with deploy
+        run:
+          mvn --no-transfer-progress antrun:run@jextract
+          sed -i '${{env.TS_SHARED}}' -e '/C_LONG =/s/"long"/"long long"/'
+        env:
+          TS_SHARED: target/generated-sources/jextract/io/github/treesitter/jtreesitter/internal/TreeSitter$shared.java
       - name: Upload jextract generated code
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,17 @@ jobs:
     name: Generate jextract code on Linux
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          # NOTE: keep this in sync with deploy
+          java-version: 25
+          cache: maven
       - name: Set up jextract
         shell: bash
         run: |-
@@ -43,6 +54,8 @@ jobs:
         env:
           # NOTE: keep this in sync with deploy, docs
           JEXTRACT_URL: https://download.java.net/java/early_access/jextract/25/1/openjdk-25-jextract+1-1
+      - name: Generate code
+        run: mvn --no-transfer-progress generate-sources
       - name: Upload jextract generated code
         uses: actions/upload-artifact@v6
         with:
@@ -110,12 +123,14 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: jextract-linux-code
+          path: target/generated-sources/jextract
       - name: Set up jextract
         if: ${{ !matrix.use-jextract-linux-code }}
         shell: bash
         run: |-
           if [[ $RUNNER_OS == Linux ]]; then
-            JEXTRACT_URL+=_linux-x64_bin.tar.gz
+            echo "Linux jextract code should have been used from dedicated job"
+            exit 1
           elif [[ $RUNNER_OS == macOS ]]; then
             JEXTRACT_URL+=_macos-aarch64_bin.tar.gz
           else
@@ -127,7 +142,7 @@ jobs:
           # NOTE: keep this in sync with deploy, docs
           JEXTRACT_URL: https://download.java.net/java/early_access/jextract/25/1/openjdk-25-jextract+1-1
       - name: Run tests
-        run: mvn --no-transfer-progress test -Djextract.skip=${{ matrix.use-jextract-linux-code }}
+        run: mvn --no-transfer-progress test "-Djextract.skip=${{ matrix.use-jextract-linux-code }}"
       - name: Patch SpotBugs SARIF report
         if: "!cancelled() && github.event_name == 'push'"
         run: mvn antrun:run@patch-sarif

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,46 @@ permissions:
   security-events: write
 
 jobs:
+  jextract-linux:
+    name: Generate jextract code on Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up jextract
+        shell: bash
+        run: |-
+          curl -LSs '${{env.JEXTRACT_URL}}_linux-x64_bin.tar.gz' | tar xzf - -C "$RUNNER_TOOL_CACHE"
+          printf '%s/jextract-25/bin\n' "$RUNNER_TOOL_CACHE" >> "$GITHUB_PATH"
+        env:
+          # NOTE: keep this in sync with deploy, docs
+          JEXTRACT_URL: https://download.java.net/java/early_access/jextract/25/1/openjdk-25-jextract+1-1
+      - name: Upload jextract generated code
+        uses: actions/upload-artifact@v6
+        with:
+          name: jextract-linux-code
+          path: target/generated-sources/jextract
+          if-no-files-found: error
   test:
     name: Test package
+    needs: jextract-linux
     strategy:
       fail-fast: false
       matrix:
         target: [ubuntu-latest, windows-latest, macos-latest]
         java-version: [23, 24, 25]
+        # To match the release build workflow, use the jextract generated code for Linux and
+        # verify that it is portable
+        use-jextract-linux-code: [true]
+        # Additionally check for non-Linux platforms that the complete build setup, including running
+        # jextract on that platform, works as well
+        # This is mainly relevant for users building the project locally, since the release workflow
+        # uses only the jextract code from Linux
+        include:
+          - target: windows-latest
+            java-version: 25
+            use-jextract-linux-code: false
+          - target: macos-latest
+            java-version: 25
+            use-jextract-linux-code: false
     runs-on: ${{matrix.target}}
     steps:
       - name: Checkout repository
@@ -72,7 +105,13 @@ jobs:
             -DCMAKE_INSTALL_BINDIR=lib \
             -DCMAKE_INSTALL_PREFIX="$RUNNER_TOOL_CACHE/tree-sitter/lib"
           cmake --build build && cmake --install build --config Debug
+      - name: Download jextract generated code for Linux
+        if: ${{ matrix.use-jextract-linux-code }}
+        uses: actions/download-artifact@v7
+        with:
+          name: jextract-linux-code
       - name: Set up jextract
+        if: ${{ !matrix.use-jextract-linux-code }}
         shell: bash
         run: |-
           if [[ $RUNNER_OS == Linux ]]; then
@@ -88,7 +127,7 @@ jobs:
           # NOTE: keep this in sync with deploy, docs
           JEXTRACT_URL: https://download.java.net/java/early_access/jextract/25/1/openjdk-25-jextract+1-1
       - name: Run tests
-        run: mvn --no-transfer-progress test
+        run: mvn --no-transfer-progress test -Djextract.skip=${{ matrix.use-jextract-linux-code }}
       - name: Patch SpotBugs SARIF report
         if: "!cancelled() && github.event_name == 'push'"
         run: mvn antrun:run@patch-sarif


### PR DESCRIPTION
Relates to #171 and #172

Changes the `ci.yml` workflow so that it is more similar to the `deploy.yml` workflow, by running jextract on Linux and then using that code on the other platforms (Windows and macOS).

The changes have this effect:
- All previously existing job matrix runs now use the jextract code generated for Linux on JDK 25
  (to match what `deploy.yml` is doing; this also surfaces the failures of #171)
- 2 new matrix jobs where added, one for Windows and one for macOS, which run jextract themselves
  (this is mainly to ensure that local builds on these platforms work, in case users build the project themselves instead of using the release versions)

What do you think?