### PR TITLE
Collect source text from ParseCallback during parsing

### DIFF
--- a/src/main/java/io/github/treesitter/jtreesitter/Parser.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/Parser.java
@@ -260,6 +260,7 @@ public final class Parser implements AutoCloseable {
         if (language == null) {
             throw new IllegalStateException("The parser has no language assigned");
         }
+        final var collected = new StringBuilder();
 
         var input = TSInput.allocate(arena);
         TSInput.payload(input, MemorySegment.NULL);
@@ -271,6 +272,7 @@ public final class Parser implements AutoCloseable {
                         bytes.set(C_INT, 0, 0);
                         return MemorySegment.NULL;
                     }
+                    collected.append(result);
                     var buffer = result.getBytes(encoding.charset());
                     bytes.set(C_INT, 0, buffer.length);
                     return arena.allocateFrom(C_CHAR, buffer);
@@ -295,7 +297,7 @@ public final class Parser implements AutoCloseable {
             tree = ts_parser_parse_with_options(self, old, input, parseOptions);
         }
         if (tree.equals(MemorySegment.NULL)) return Optional.empty();
-        return Optional.of(new Tree(tree, language, null, null));
+        return Optional.of(new Tree(tree, language, collected.toString(), encoding.charset()));
     }
 
     /**

--- a/src/main/java/io/github/treesitter/jtreesitter/Parser.java
+++ b/src/main/java/io/github/treesitter/jtreesitter/Parser.java
@@ -260,7 +260,7 @@ public final class Parser implements AutoCloseable {
         if (language == null) {
             throw new IllegalStateException("The parser has no language assigned");
         }
-        final var collected = new StringBuilder();
+        final var collected = new java.io.ByteArrayOutputStream();
 
         var input = TSInput.allocate(arena);
         TSInput.payload(input, MemorySegment.NULL);
@@ -272,8 +272,16 @@ public final class Parser implements AutoCloseable {
                         bytes.set(C_INT, 0, 0);
                         return MemorySegment.NULL;
                     }
-                    collected.append(result);
                     var buffer = result.getBytes(encoding.charset());
+                    var collectedSize = collected.size();
+                    if (index >= collectedSize) {
+                        collected.write(buffer, 0, buffer.length);
+                    } else {
+                        var overlap = collectedSize - index;
+                        if (overlap < buffer.length) {
+                            collected.write(buffer, overlap, buffer.length - overlap);
+                        }
+                    }
                     bytes.set(C_INT, 0, buffer.length);
                     return arena.allocateFrom(C_CHAR, buffer);
                 },
@@ -297,7 +305,7 @@ public final class Parser implements AutoCloseable {
             tree = ts_parser_parse_with_options(self, old, input, parseOptions);
         }
         if (tree.equals(MemorySegment.NULL)) return Optional.empty();
-        return Optional.of(new Tree(tree, language, collected.toString(), encoding.charset()));
+        return Optional.of(new Tree(tree, language, collected.toByteArray(), encoding.charset()));
     }
 
     /**

--- a/src/test/java/io/github/treesitter/jtreesitter/ParserTest.java
+++ b/src/test/java/io/github/treesitter/jtreesitter/ParserTest.java
@@ -106,10 +106,10 @@ class ParserTest {
     @DisplayName("parse(callback)")
     void parseCallback() {
         var source = "class Foo {}";
-        ParseCallback callback = (offset, _) -> source.substring(offset, Integer.min(offset, source.length()));
+        ParseCallback callback = (offset, _) -> source.substring(offset, Integer.min(source.length(), offset + 1));
         parser.setLanguage(language);
         try (var tree = parser.parse(callback, InputEncoding.UTF_8).orElseThrow()) {
-            assertNull(tree.getText());
+            assertEquals(source, tree.getText());
             assertEquals("program", tree.getRootNode().getType());
         }
     }


### PR DESCRIPTION
This change collects source text returned by `ParseCallback` during parsing and stores it in the resulting `Tree`.

Previously, trees created from `ParseCallback` did not retain source text, causing methods like `getText()` and `Node.getText()` to return `null`. This change enables text-related APIs for callback-based parsing.

This also updates the callback parsing test to assert the new behavior.

Fixes #126
